### PR TITLE
manifest: Track QCOM-CAF for msm8998 from LineageOS

### DIFF
--- a/snippets/external.xml
+++ b/snippets/external.xml
@@ -27,7 +27,10 @@
   <project path="hardware/qcom-caf/bt" name="LineageOS/android_hardware_qcom_bt" groups="qcom,legacy-qcom" revision="lineage-21.0-caf" remote="LineageOS" />
   <project path="hardware/qcom-caf/msm8996/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,legacy-qcom" revision="lineage-21.0-caf-msm8996" remote="LineageOS" />
   <project path="hardware/qcom-caf/msm8996/display" name="LineageOS/android_hardware_qcom_display" groups="qcom,legacy-qcom" revision="lineage-21.0-caf-msm8996" remote="LineageOS" />
-  <project path="hardware/qcom-caf/msm8996/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,legacy-qcom" revision="lineage-21.0-caf-msm8996" remote="LineageOS" />
+  <project path="hardware/qcom-caf/msm8996/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,msm8998" revision="lineage-21.0-caf-msm8996" remote="LineageOS" />
+  <project path="hardware/qcom-caf/msm8998/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,msm8998" revision="lineage-21.0-caf-msm8998" remote="LineageOS" />
+  <project path="hardware/qcom-caf/msm8998/display" name="LineageOS/android_hardware_qcom_display" groups="qcom,msm8998" revision="lineage-21.0-caf-msm8998" remote="LineageOS" />
+  <project path="hardware/qcom-caf/msm8998/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,legacy-qcom" revision="lineage-21.0-caf-msm8998" remote="LineageOS" />
   <project path="hardware/qcom-caf/sdm660/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,sdm660" revision="lineage-21.0-caf-sdm660" remote="LineageOS" />
   <project path="hardware/qcom-caf/sdm660/display" name="LineageOS/android_hardware_qcom_display" groups="qcom" revision="lineage-21.0-caf-sdm660" remote="LineageOS" />
   <project path="hardware/qcom-caf/sdm660/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,sdm660" revision="lineage-21.0-caf-sdm660" remote="LineageOS" />

--- a/snippets/voltage.xml
+++ b/snippets/voltage.xml
@@ -109,9 +109,6 @@
     <linkfile src="os_pickup_qssi.bp" dest="hardware/qcom-caf/sm8550/Android.bp" />
     <linkfile src="os_pickup.mk" dest="hardware/qcom-caf/sm8550/Android.mk" />
   </project>
-  <project path="hardware/qcom-caf/msm8998/audio" name="hardware_qcom_audio" revision="14-msm8998" remote="vos" />
-  <project path="hardware/qcom-caf/msm8998/display" name="hardware_qcom_display" revision="14-msm8998" remote="vos" />
-  <project path="hardware/qcom-caf/msm8998/media" name="hardware_qcom_media" revision="14-msm8998" remote="vos" />
 
   <!-- Hardware Pixel -->
   <project path="hardware/google/gchips" name="hardware_google_gchips" remote="vos" />


### PR DESCRIPTION
The display HAL is causing no screen output on some devices and the HALs seems to be outdated :-( Take them from LineageOS which are working fine on Nokia MSM8998 devices.

Change-Id: I035f5f71e1ef577ffd3113c16c102a876cfe2788